### PR TITLE
arq: acknowledge event by reading from fd

### DIFF
--- a/output/ip/arq.c
+++ b/output/ip/arq.c
@@ -89,6 +89,7 @@
 static void catch_event(struct upump *upump)
 {
     struct arq_ctx *ctx = upump->opaque;
+    ueventfd_read(ctx->event);
     pthread_mutex_lock(&ctx->mutex);
     bool end = ctx->end;
     pthread_mutex_unlock(&ctx->mutex);


### PR DESCRIPTION
poll() goes back to blocking rather than spamming us